### PR TITLE
#2: Build for the RPi

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+# don't inherit the environment, set up from scratch
+
+script_dir="$(realpath "$(dirname "$0")")"
+machine="raspberrypi3-64"
+distro="remote-led-distro"
+architecture="aarch64"
+image="core-image-remote-led"
+
+pushd "$script_dir"
+source poky/oe-init-build-env
+bitbake-layers add-layer "$script_dir/meta-remote_led"
+bitbake-layers layerindex-fetch meta-oe
+bitbake-layers layerindex-fetch meta-raspberrypi
+MACHINE="$machine" DISTRO="$distro" ARCH="$architecture" bitbake "$image"

--- a/meta-remote_led/conf/distro/remote-led-distro.conf
+++ b/meta-remote_led/conf/distro/remote-led-distro.conf
@@ -1,1 +1,3 @@
 DISTRO_FEATURES:remove = "bluetooth zeroconf opengl wayland vulcan avahi alsa"
+# req'd for some raspberry pi drivers
+LICENSE_FLAGS_ACCEPTED = "synaptics-killswitch"

--- a/meta-remote_led/recipes-remote_led/images/core-image-remote-led.bb
+++ b/meta-remote_led/recipes-remote_led/images/core-image-remote-led.bb
@@ -1,2 +1,3 @@
-inherit core-image
+inherit core-image sdcard_image-rpi
 CORE_IMAGE_EXTRA_INSTALL += "remote-led"
+IMAGE_FSTYPES:append = " rpi-sdimg"


### PR DESCRIPTION
This PR adds a script (`build.sh`) that builds the image for the RPi board, which can be programmed via the Raspberry Pi SD Card imager.

Testing: using `build.sh`, build an SD card image, burned that image to a RPi 3B+, and then booted the Pi.  The userspace application from #3 was present in the image and worked as expected.

This PR can close #2.