### PR TITLE
#4: Kernel Module Stub

### DIFF
--- a/kernelspace/rgb-led/Makefile
+++ b/kernelspace/rgb-led/Makefile
@@ -1,0 +1,14 @@
+obj-m := rgb-led.o
+
+SRC := $(shell pwd)
+
+all:
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC)
+
+modules_install:
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) modules_install
+
+clean:
+	rm -f *.o *~ core .depend .*.cmd *.ko *.mod.c
+	rm -f Module.markers Module.symvers modules.order
+	rm -rf .tmp_versions Modules.symvers

--- a/kernelspace/rgb-led/rgb-led.c
+++ b/kernelspace/rgb-led/rgb-led.c
@@ -1,0 +1,24 @@
+/******************************************************************************
+ *
+ *   Copyright (C) 2011  Intel Corporation. All rights reserved.
+ *
+ *   SPDX-License-Identifier: GPL-2.0-only
+ *
+ *****************************************************************************/
+
+#include <linux/module.h>
+
+static int __init rgb_led_init(void)
+{
+	pr_info("Hello World!\n");
+	return 0;
+}
+
+static void __exit rgb_led_exit(void)
+{
+	pr_info("Goodbye Cruel World!\n");
+}
+
+module_init(rgb_led_init);
+module_exit(rgb_led_exit);
+MODULE_LICENSE("GPL");

--- a/meta-remote_led/recipes-remote_led/images/core-image-remote-led.bb
+++ b/meta-remote_led/recipes-remote_led/images/core-image-remote-led.bb
@@ -1,2 +1,4 @@
 inherit core-image
 CORE_IMAGE_EXTRA_INSTALL += "remote-led"
+CORE_IMAGE_EXTRA_INSTALL += "rgb-led"
+CORE_IMAGE_EXTRA_INSTALL += "kernel-modules"

--- a/meta-remote_led/recipes-remote_led/rgb-led/rgb-led.bb
+++ b/meta-remote_led/recipes-remote_led/rgb-led/rgb-led.bb
@@ -1,0 +1,15 @@
+LICENSE = "CLOSED"
+LIC_FILES_CHKSUM = ""
+
+inherit module
+
+KERNELSPACE_SOURCE_PATH = "/workspaces/final-project-bennowotny/kernelspace"
+
+FILESEXTRAPATHS:prepend := "${KERNELSPACE_SOURCE_PATH}:"
+SRC_URI = "file://rgb-led/"
+S = "${WORKDIR}/rgb-led"
+
+# The inherit of module.bbclass will automatically name module packages with
+# "kernel-module-" prefix as required by the oe-core build environment.
+
+RPROVIDES:${PN} += "kernel-module-rgb-led"


### PR DESCRIPTION
Added a kernel module stub based off the Yocto template.  It is a part of the main `core-image-remote-led` image.

Testing: Using `build.sh` to build a new RPi image and deployed to hardware.  The new kernel module built successfully and was loaded/removed successfully with `modprobe [-r]`.

This PR can close #4.