### PR TITLE
#8: Network Interface Implementation

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /home/devcontainer
 RUN rm -rf cmake-3.28.0
 
 # Add yocto tools
-RUN apt install -y gawk wget diffstat unzip texinfo gcc chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 python3-subunit zstd liblz4-tool file locales libacl1
+RUN apt install -y gawk wget diffstat unzip texinfo gcc chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 python3-subunit zstd liblz4-tool file locales libacl1 bear
 RUN locale-gen en_US.UTF-8
 
 RUN usermod -aG sudo devcontainer

--- a/userspace/remote-led/.vscode/settings.json
+++ b/userspace/remote-led/.vscode/settings.json
@@ -29,5 +29,6 @@
     ],
     "cmake.configureOnEdit": true,
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
+    "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd",
+    "git.openRepositoryInParentFolders": "always"
 }

--- a/userspace/remote-led/app/CMakeLists.txt
+++ b/userspace/remote-led/app/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(remote-led)
 target_sources(remote-led PRIVATE main.cpp)
-target_link_libraries(remote-led PRIVATE rgb-color)
+target_link_libraries(remote-led PRIVATE rgb-color networking)
 
 install(TARGETS remote-led RUNTIME)

--- a/userspace/remote-led/app/main.cpp
+++ b/userspace/remote-led/app/main.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
   LockableWrapper<std::ofstream> rgbOutput{std::ofstream{RGB_COLOR_ENDPOINT, std::ios::binary}};
 
   static constexpr networking::PortNumber PORT_NUMBER{18658};
-  static constexpr std::size_t MAX_PENDING_CONNECTIONS{1}; // only 1 thing should set the LED at a time
+  static constexpr std::size_t MAX_PENDING_CONNECTIONS{20};
   networking::Socket socket{
       PORT_NUMBER,
       MAX_PENDING_CONNECTIONS,

--- a/userspace/remote-led/app/main.cpp
+++ b/userspace/remote-led/app/main.cpp
@@ -29,17 +29,14 @@ int main(int argc, char **argv) {
       [&](const std::stop_token & /* token */, networking::Connection &connection, std::promise<void> complete) {
         complete.set_value_at_thread_exit();
         const auto data{connection.getData(3)};
-        std::cout << "Heard connection!" << std::endl;
         if (data.size() != 3)
           return;
         const auto color{rgb::fromBytes(data)};
         (*rgbOutput.acquire()) << color << std::flush;
-        std::cout << rgb::prettyPrint(color) << std::flush;
       }};
 
   int terminatingSignal{0};
   sigwait(&blockedSignals, &terminatingSignal);
-  std::cout << "Program terminated with signal " << terminatingSignal << std::endl;
 
   return 0;
 }

--- a/userspace/remote-led/libs/CMakeLists.txt
+++ b/userspace/remote-led/libs/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_subdirectory(rgb-color)
+add_subdirectory(networking)
+add_subdirectory(util)

--- a/userspace/remote-led/libs/networking/CMakeLists.txt
+++ b/userspace/remote-led/libs/networking/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_library(networking)
-target_sources(networking PRIVATE src/Socket.cpp)
+target_sources(networking PRIVATE src/Socket.cpp src/Connection.cpp)
 target_include_directories(networking PUBLIC include)
 target_link_libraries(networking PUBLIC util)

--- a/userspace/remote-led/libs/networking/CMakeLists.txt
+++ b/userspace/remote-led/libs/networking/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(networking)
+target_sources(networking PRIVATE src/Socket.cpp)
+target_include_directories(networking PUBLIC include)
+target_link_libraries(networking PUBLIC util)

--- a/userspace/remote-led/libs/networking/include/networking/Connection.hpp
+++ b/userspace/remote-led/libs/networking/include/networking/Connection.hpp
@@ -1,8 +1,23 @@
 #ifndef NETWORKING_CONNECTION_HPP
 #define NETWORKING_CONNECTION_HPP
 
+#include <cstddef>
+#include <vector>
+
 namespace networking {
 class Connection {
+public:
+  explicit Connection(int fd);
+  ~Connection() noexcept;
+  Connection(const Connection &) = delete;
+  Connection &operator=(const Connection &) = delete;
+  Connection(Connection &&) = delete;
+  Connection &operator=(Connection &&) = delete;
+
+  std::vector<std::byte> getData(std::size_t bytes_requested);
+
+private:
+  int m_fd;
 };
 } // namespace networking
 

--- a/userspace/remote-led/libs/networking/include/networking/Connection.hpp
+++ b/userspace/remote-led/libs/networking/include/networking/Connection.hpp
@@ -1,0 +1,9 @@
+#ifndef NETWORKING_CONNECTION_HPP
+#define NETWORKING_CONNECTION_HPP
+
+namespace networking {
+class Connection {
+};
+} // namespace networking
+
+#endif

--- a/userspace/remote-led/libs/networking/include/networking/Socket.hpp
+++ b/userspace/remote-led/libs/networking/include/networking/Socket.hpp
@@ -1,0 +1,40 @@
+#ifndef NETWORKING_SOCKET_HPP
+#define NETWORKING_SOCKET_HPP
+
+#include "networking/Connection.hpp"
+#include <future>
+#include <thread>
+#include <util/StrongType.hpp>
+#include <vector>
+
+namespace networking {
+
+using PortNumber = StrongType<int, struct NetworkingPortNumber>;
+using ConnectionCallback = std::function<void(const std::stop_token &, Connection)>;
+
+class Socket {
+public:
+  Socket(PortNumber port, ConnectionCallback onConnection);
+  ~Socket() noexcept;
+  Socket(const Socket &) = delete;
+  Socket &operator=(const Socket &) = delete;
+  Socket(Socket &&) = delete;
+  Socket &operator=(Socket &&) = delete;
+
+private:
+  void handleNewConnections(std::stop_token stopToken);
+
+  std::jthread m_handleNewConnections;
+  ConnectionCallback m_onConnection;
+
+  struct ConnectionThreadStatus {
+    std::jthread connectionThread;
+    std::future<ConnectionCallback::result_type> completionSignal;
+  };
+
+  std::vector<ConnectionThreadStatus> m_connectionThreadCompletion{};
+};
+
+} // namespace networking
+
+#endif

--- a/userspace/remote-led/libs/networking/include/networking/Socket.hpp
+++ b/userspace/remote-led/libs/networking/include/networking/Socket.hpp
@@ -3,18 +3,20 @@
 
 #include "networking/Connection.hpp"
 #include <future>
+#include <latch>
 #include <thread>
+#include <util/LockableWrapper.hpp>
 #include <util/StrongType.hpp>
 #include <vector>
 
 namespace networking {
 
-using PortNumber = StrongType<int, struct NetworkingPortNumber>;
-using ConnectionCallback = std::function<void(const std::stop_token &, Connection)>;
+using PortNumber = StrongType<uint16_t, struct NetworkingPortNumber>;
+using ConnectionCallback = std::function<void(const std::stop_token &, Connection &, std::promise<void>)>;
 
 class Socket {
 public:
-  Socket(PortNumber port, ConnectionCallback onConnection);
+  Socket(PortNumber port, std::size_t pendingConnections, ConnectionCallback onConnection);
   ~Socket() noexcept;
   Socket(const Socket &) = delete;
   Socket &operator=(const Socket &) = delete;
@@ -24,6 +26,8 @@ public:
 private:
   void handleNewConnections(std::stop_token stopToken);
 
+  // main thread and connection thread need to synchronize - 2 arrivals
+  std::latch m_waitToListenForConnections{2};
   std::jthread m_handleNewConnections;
   ConnectionCallback m_onConnection;
 
@@ -32,7 +36,9 @@ private:
     std::future<ConnectionCallback::result_type> completionSignal;
   };
 
-  std::vector<ConnectionThreadStatus> m_connectionThreadCompletion{};
+  LockableWrapper<std::vector<ConnectionThreadStatus>> m_connectionThreads{};
+
+  int m_socketFd;
 };
 
 } // namespace networking

--- a/userspace/remote-led/libs/networking/src/Connection.cpp
+++ b/userspace/remote-led/libs/networking/src/Connection.cpp
@@ -1,0 +1,23 @@
+#include "networking/Connection.hpp"
+#include <stdexcept>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace networking {
+Connection::Connection(int fd) : m_fd{fd} {}
+
+Connection::~Connection() noexcept { close(m_fd); }
+
+std::vector<std::byte> Connection::getData(std::size_t bytes_requested) {
+  std::vector<std::byte> data;
+  data.resize(bytes_requested);
+  auto recvdDataSize{recv(m_fd, data.data(), bytes_requested, 0)};
+  if (recvdDataSize < 0) {
+    using namespace std::string_literals;
+    throw std::runtime_error{"Could not receive data from connection "s + std::to_string(m_fd)};
+  }
+  data.erase(data.begin() + recvdDataSize, data.end());
+  data.shrink_to_fit();
+  return data;
+}
+} // namespace networking

--- a/userspace/remote-led/libs/networking/src/Socket.cpp
+++ b/userspace/remote-led/libs/networking/src/Socket.cpp
@@ -1,14 +1,118 @@
 #include "networking/Socket.hpp"
+#include "networking/Connection.hpp"
+#include "util/OnCleanup.hpp"
+#include <algorithm>
+#include <future>
+#include <netdb.h>
+#include <poll.h>
+#include <stdexcept>
 #include <stop_token>
+#include <string>
+#include <strings.h>
+#include <sys/socket.h>
+
+using namespace std::chrono_literals;
 
 namespace networking {
 
-Socket::Socket(PortNumber port, ConnectionCallback onConnection) : m_onConnection{std::move(onConnection)},
-                                                                   m_handleNewConnections{
-                                                                       [this](std::stop_token token) { handleNewConnections(token); }} {}
+Socket::Socket(PortNumber port, std::size_t pendingConnections, ConnectionCallback onConnection) : m_onConnection{std::move(onConnection)},
+                                                                                                   m_handleNewConnections{
+                                                                                                       [this](std::stop_token token) { handleNewConnections(token); }} {
 
-Socket::~Socket() noexcept {}
+  const auto socketFd = socket(AF_INET, SOCK_STREAM, 0);
+  if (socketFd == -1) {
+    throw std::runtime_error{"Could not create socket"};
+  }
+  OnCleanup cleanupSocket{[&socketFd] { close(socketFd); }};
 
-void Socket::handleNewConnections(std::stop_token stopToken) {}
+  // allow socket reuse
+  const int optionValue{1};
+  setsockopt(m_socketFd, SOL_SOCKET, SO_REUSEADDR, &optionValue, sizeof(optionValue));
+
+  {
+    addrinfo hints;
+    // Scoped in to destroy when finished using this
+    addrinfo *addrResult;
+    OnCleanup cleanupAddrInfo{[&addrResult] { freeaddrinfo(addrResult); }};
+
+    bzero(&hints, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+
+    if (getaddrinfo(nullptr, std::to_string(port.get()).c_str(), &hints, &addrResult) != 0) {
+      throw std::runtime_error{"Could not get address to bind to"};
+    }
+
+    if (bind(socketFd, addrResult->ai_addr, sizeof(sockaddr)) != 0) {
+      throw std::runtime_error{"Could not bind to address"};
+    }
+  }
+
+  if (listen(socketFd, pendingConnections)) {
+    throw std::runtime_error{"Could not start listening for connections"};
+  }
+
+  m_socketFd = socketFd;
+  // we succeeded in setting up the socket, don't close it here
+  cleanupSocket.cancelCleanup();
+
+  // start a thread to process incoming connections
+  m_waitToListenForConnections.arrive_and_wait();
+}
+
+Socket::~Socket() noexcept {
+  close(m_socketFd);
+}
+
+void Socket::handleNewConnections(std::stop_token stopToken) {
+  m_waitToListenForConnections.arrive_and_wait();
+
+  while (true) {
+    // wait for a connection to be available before accept()
+    // otherwise, we can't terminate this thread, since signals need to be blocked
+    while (!stopToken.stop_requested()) {
+      struct pollfd socketPoll;
+      socketPoll.fd = m_socketFd;
+      socketPoll.events = POLLIN;
+      const auto pollStatus{poll(&socketPoll, 1, 1000)};
+      if (pollStatus < 0) {
+        throw std::runtime_error{"Could not wait for a connection"};
+      } else if (pollStatus > 0)
+        break; // we have a connection
+      // ignore pollStatus == 0, that means there was a timeout and we should check again
+    }
+
+    struct sockaddr connectedAddr;
+    socklen_t addrLen{sizeof(connectedAddr)};
+    const auto connectionFd{accept(m_socketFd, &connectedAddr, &addrLen)};
+
+    if (connectionFd == -1)
+      break;
+
+    std::promise<void> threadCompletionPromise;
+    auto completionFuture{threadCompletionPromise.get_future()};
+    m_connectionThreads.acquire()->emplace_back(ConnectionThreadStatus{.connectionThread{std::jthread{[&](auto token) {
+                                                                         Connection connection{connectionFd};
+                                                                         m_onConnection(token, connection, std::move(threadCompletionPromise));
+                                                                       }}},
+                                                                       .completionSignal{std::move(completionFuture)}});
+
+    // sweep for complete threads
+    {
+      auto threads{m_connectionThreads.acquire()};
+      std::sort(threads->begin(), threads->end(), [](const ConnectionThreadStatus &lhs, const ConnectionThreadStatus &rhs) {
+        return lhs.completionSignal.wait_for(0s) == std::future_status::ready && rhs.completionSignal.wait_for(0s) == std::future_status::timeout;
+      });
+      // running threads are now first in the list
+      // erase from the first complete thread to the end
+      const auto firstComplete{std::find_if(threads->begin(), threads->end(),
+                                            [](const auto &x) {
+                                              return x.completionSignal.wait_for(0s) == std::future_status::timeout;
+                                            })};
+      threads->erase(firstComplete, threads->end());
+    }
+  }
+}
 
 } // namespace networking

--- a/userspace/remote-led/libs/networking/src/Socket.cpp
+++ b/userspace/remote-led/libs/networking/src/Socket.cpp
@@ -15,9 +15,10 @@ using namespace std::chrono_literals;
 
 namespace networking {
 
-Socket::Socket(PortNumber port, std::size_t pendingConnections, ConnectionCallback onConnection) : m_onConnection{std::move(onConnection)},
-                                                                                                   m_handleNewConnections{
-                                                                                                       [this](std::stop_token token) { handleNewConnections(token); }} {
+Socket::Socket(PortNumber port, std::size_t pendingConnections, ConnectionCallback onConnection)
+    : m_onConnection{std::move(onConnection)},
+      m_handleNewConnections{
+          [this](std::stop_token token) { handleNewConnections(token); }} {
 
   const auto socketFd = socket(AF_INET, SOCK_STREAM, 0);
   if (socketFd == -1) {

--- a/userspace/remote-led/libs/networking/src/Socket.cpp
+++ b/userspace/remote-led/libs/networking/src/Socket.cpp
@@ -1,0 +1,14 @@
+#include "networking/Socket.hpp"
+#include <stop_token>
+
+namespace networking {
+
+Socket::Socket(PortNumber port, ConnectionCallback onConnection) : m_onConnection{std::move(onConnection)},
+                                                                   m_handleNewConnections{
+                                                                       [this](std::stop_token token) { handleNewConnections(token); }} {}
+
+Socket::~Socket() noexcept {}
+
+void Socket::handleNewConnections(std::stop_token stopToken) {}
+
+} // namespace networking

--- a/userspace/remote-led/libs/rgb-color/include/rgb-color/RGBColor.hpp
+++ b/userspace/remote-led/libs/rgb-color/include/rgb-color/RGBColor.hpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <ostream>
+#include <vector>
 
 namespace rgb {
 
@@ -14,6 +15,7 @@ struct RGBColor {
 
 std::ostream &operator<<(std::ostream &stream, const RGBColor &color);
 std::string prettyPrint(const RGBColor &color);
+RGBColor fromBytes(const std::vector<std::byte> &bytes);
 
 } // namespace rgb
 

--- a/userspace/remote-led/libs/rgb-color/src/RGBColor.cpp
+++ b/userspace/remote-led/libs/rgb-color/src/RGBColor.cpp
@@ -1,6 +1,7 @@
 #include "rgb-color/RGBColor.hpp"
 
 #include <sstream>
+#include <stdexcept>
 
 namespace rgb {
 
@@ -13,6 +14,14 @@ std::string prettyPrint(const rgb::RGBColor &color) {
   std::stringstream stream;
   stream << std::hex << std::showbase << "{ red: " << +(color.red) << ", green: " << +(color.green) << ", blue: " << +(color.blue) << " }";
   return stream.str();
+}
+
+RGBColor fromBytes(const std::vector<std::byte> &bytes) {
+  if (bytes.size() != 3)
+    throw std::invalid_argument{"RGB colors should be only 3 bytes"};
+
+  return {
+      .red{static_cast<uint8_t>(bytes.at(0))}, .green{static_cast<uint8_t>(bytes.at(1))}, .blue{static_cast<uint8_t>(bytes.at(2))}};
 }
 
 } // namespace rgb

--- a/userspace/remote-led/libs/util/CMakeLists.txt
+++ b/userspace/remote-led/libs/util/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(util INTERFACE)
+target_include_directories(util INTERFACE include)

--- a/userspace/remote-led/libs/util/include/util/LockableWrapper.hpp
+++ b/userspace/remote-led/libs/util/include/util/LockableWrapper.hpp
@@ -1,0 +1,43 @@
+#ifndef UTIL_LOCKABLEWRAPPER_HPP
+#define UTIL_LOCKABLEWRAPPER_HPP
+
+#include <mutex>
+
+template <typename T>
+class Locked {
+public:
+  Locked(T *m_data, std::mutex &mutex) : m_data{m_data}, m_guard{mutex} {}
+
+  T &operator*() { return *m_data; }
+
+  const T &operator*() const { return *m_data; }
+
+  T *operator->() { return m_data; }
+
+  const T *operator->() const { return m_data; }
+
+private:
+  T *m_data;
+  std::lock_guard<std::mutex> m_guard;
+};
+
+template <typename T>
+class LockableWrapper {
+public:
+  explicit LockableWrapper(T data) : m_data{std::move(data)} {}
+
+  ~LockableWrapper() noexcept {
+    // ensure object isn't Locked on destruction
+    std::lock_guard guard{m_mutex};
+  }
+
+  Locked<T> acquire() {
+    return Locked<T>{&m_data, m_mutex};
+  }
+
+private:
+  T m_data;
+  std::mutex m_mutex;
+};
+
+#endif

--- a/userspace/remote-led/libs/util/include/util/LockableWrapper.hpp
+++ b/userspace/remote-led/libs/util/include/util/LockableWrapper.hpp
@@ -24,6 +24,8 @@ private:
 template <typename T>
 class LockableWrapper {
 public:
+  LockableWrapper() noexcept = default;
+
   explicit LockableWrapper(T data) : m_data{std::move(data)} {}
 
   ~LockableWrapper() noexcept {

--- a/userspace/remote-led/libs/util/include/util/OnCleanup.hpp
+++ b/userspace/remote-led/libs/util/include/util/OnCleanup.hpp
@@ -1,0 +1,25 @@
+#ifndef UTIL_ONCLEANUP_HPP
+#define UTIL_ONCLEANUP_HPP
+
+#include <concepts>
+#include <utility>
+
+template <typename Callable>
+  requires std::invocable<Callable>
+class OnCleanup {
+public:
+  explicit OnCleanup(Callable callable) : m_callable{std::move(callable)} {}
+
+  ~OnCleanup() {
+    if (m_canCleanup)
+      m_callable();
+  }
+
+  void cancelCleanup() { m_canCleanup = false; }
+
+private:
+  Callable m_callable;
+  bool m_canCleanup{true};
+};
+
+#endif

--- a/userspace/remote-led/libs/util/include/util/StrongType.hpp
+++ b/userspace/remote-led/libs/util/include/util/StrongType.hpp
@@ -1,0 +1,19 @@
+#ifndef UTIL_STRONGTYPE_HPP
+#define UTIL_STRONGTYPE_HPP
+
+#include <utility>
+
+template <typename T, typename Token>
+class StrongType {
+public:
+  explicit StrongType(T val) : m_val{std::move(val)} {}
+
+  const T &get() const noexcept { return m_val; }
+
+  T &get() noexcept { return m_val; }
+
+private:
+  T m_val;
+};
+
+#endif

--- a/userspace/remote-led/libs/util/include/util/StrongType.hpp
+++ b/userspace/remote-led/libs/util/include/util/StrongType.hpp
@@ -6,7 +6,7 @@
 template <typename T, typename Token>
 class StrongType {
 public:
-  explicit StrongType(T val) : m_val{std::move(val)} {}
+  explicit constexpr StrongType(T val) : m_val{std::move(val)} {}
 
   const T &get() const noexcept { return m_val; }
 


### PR DESCRIPTION
Adds a socket to the userspace application and routes incoming 3 byte messages into color structs, which then use the interface from #7 to write to a file.

Testing:  built a new image with the updated application and used `echo -n '<msg>' | nc -w 1 <address>:18658` to send test bytes.  The bytes were appended to the file in the order expected, messages that couldn't be parsed (messages not 3 bytes in length) were ignored.

This PR can close #8.
