### PR TITLE
#6: Implement PWM Bit-Banging

### DIFF
--- a/kernelspace/rgb-led/.clangd
+++ b/kernelspace/rgb-led/.clangd
@@ -1,2 +1,2 @@
 CompileFlags:
-  Remove: [-fconserve-stack, -fno-allow-store-data-races, -mabi=lp64]
+  Remove: [-fconserve-stack, -fno-allow-store-data-races, -mabi=lp64, -fcanon-prefix-map, -mcmodel*, -mno*]

--- a/kernelspace/rgb-led/.vscode/settings.json
+++ b/kernelspace/rgb-led/.vscode/settings.json
@@ -20,5 +20,6 @@
         "**/oe-logs/**",
         "**/oe-workdir/**",
         "**/source-date-epoch/**"
-    ]
+    ],
+    "git.openRepositoryInParentFolders": "always"
 }

--- a/kernelspace/rgb-led/.vscode/settings.json
+++ b/kernelspace/rgb-led/.vscode/settings.json
@@ -21,5 +21,7 @@
         "**/oe-workdir/**",
         "**/source-date-epoch/**"
     ],
-    "git.openRepositoryInParentFolders": "always"
+    "git.openRepositoryInParentFolders": "always",
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
 }

--- a/kernelspace/rgb-led/generate-intellisense.sh
+++ b/kernelspace/rgb-led/generate-intellisense.sh
@@ -8,7 +8,7 @@ source "poky/oe-init-build-env"
 bitbake -c clean rgb-led
 "$script_dir/../../build.sh"
 pushd "$script_dir" || exit 1 # go to the 'modify' workspace
-make_command="$(grep -Pho -m1 '(?<=NOTE: )make .*$' $script_dir/../../build/tmp-glibc/work/raspberrypi3_64-oe-linux/rgb-led/1.0/temp/log.do_compile)"
+make_command="$(grep -Pho -m1 '(?<=NOTE: )make .*$' $script_dir/oe-logs/log.do_compile)"
 make_command="$(echo "$make_command" | head -n1)"
 # quote the CC arguments
 make_command="${make_command/aarch64-oe-linux-gcc//workspaces/final-project-bennowotny/build/tmp-glibc/work/x86_64-linux/gcc-cross-aarch64/13.3.0/sysroot-destdir/workspaces/final-project-bennowotny/build/tmp-glibc/work/x86_64-linux/gcc-cross-aarch64/13.3.0/recipe-sysroot-native/usr/bin/aarch64-oe-linux/aarch64-oe-linux-gcc}"

--- a/kernelspace/rgb-led/rgb-led.c
+++ b/kernelspace/rgb-led/rgb-led.c
@@ -6,15 +6,49 @@
  *
  *****************************************************************************/
 
+#include <linux/hrtimer.h>
+#include <linux/moduleparam.h>
 #include <linux/gpio.h>
 #include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/ktime.h>
 
 #define GPIO_R (514) // Header J8-3
 #define GPIO_G (515) // Header J8-5
 #define GPIO_B (516) // Header J8-7
 
+int dutyCycle = 0;
+module_param(dutyCycle, int, 0);
+
+long ns = 0;
+module_param(ns, long, 200);
+
+struct hrtimer pwmCycler;
+ktime_t expTime;
+
+enum hrtimer_restart on_timer(struct hrtimer* timer){
+  static uint8_t cycleCount = 0;
+
+  hrtimer_forward_now(timer, expTime);
+  
+  if(cycleCount == 0 && dutyCycle != 0){
+    gpio_set_value(GPIO_R, 1);
+    gpio_set_value(GPIO_G, 1);
+    gpio_set_value(GPIO_B, 1);
+  }else if(cycleCount == dutyCycle){
+    gpio_set_value(GPIO_R, 0);
+    gpio_set_value(GPIO_G, 0);
+    gpio_set_value(GPIO_B, 0);
+  }
+  
+  ++cycleCount;
+  return HRTIMER_RESTART;
+}
+
 static int __init rgb_led_init(void) {
   pr_info("Hello World!\n");
+  pr_info("Using duty cycle: %d\n", dutyCycle);
 
   if (gpio_request(GPIO_R, "RGB_R") < 0) {
     pr_err("ERROR: RGB R (%d) request\n", GPIO_R);
@@ -34,6 +68,11 @@ static int __init rgb_led_init(void) {
   }
   gpio_direction_output(GPIO_B, 1);
 
+  hrtimer_init(&pwmCycler, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+  pwmCycler.function = on_timer;
+  expTime = ktime_set(0, ns); // 162760, i.t.
+  hrtimer_start(&pwmCycler, expTime, HRTIMER_MODE_REL);
+
   return 0;
 
 dealloc_gpio_b:
@@ -46,6 +85,8 @@ dealloc_gpio_r:
 
 static void __exit rgb_led_exit(void) {
   pr_info("Goodbye Cruel World!\n");
+
+  hrtimer_cancel(&pwmCycler);
 
   gpio_set_value(GPIO_R, 0);
   gpio_set_value(GPIO_G, 0);

--- a/kernelspace/rgb-led/rgb-led.c
+++ b/kernelspace/rgb-led/rgb-led.c
@@ -1,76 +1,79 @@
-/******************************************************************************
- *
- *   Copyright (C) 2011  Intel Corporation. All rights reserved.
- *
- *   SPDX-License-Identifier: GPL-2.0-only
- *
- *****************************************************************************/
-
-#include <linux/hrtimer.h>
-#include <linux/moduleparam.h>
 #include <linux/gpio.h>
-#include <linux/module.h>
+#include <linux/hrtimer.h>
 #include <linux/kernel.h>
-#include <linux/module.h>
 #include <linux/ktime.h>
+#include <linux/module.h>
+#include <linux/moduleparam.h>
 
 #define GPIO_R (514) // Header J8-3
 #define GPIO_G (515) // Header J8-5
 #define GPIO_B (516) // Header J8-7
 
-int dutyCycle = 0;
-module_param(dutyCycle, int, 0);
+// load time parameter for the duty cycle
+int redDutyCycle = 0;
+module_param(redDutyCycle, int, 0);
+int greenDutyCycle = 0;
+module_param(greenDutyCycle, int, 0);
+int blueDutyCycle = 0;
+module_param(blueDutyCycle, int, 0);
 
-long ns = 0;
+// load time parameter for the period of the PWM cycle
+long ns = 80000; // roughly 48Hz
 module_param(ns, long, 200);
 
 struct hrtimer pwmCycler;
 ktime_t expTime;
 
-enum hrtimer_restart on_timer(struct hrtimer* timer){
+enum hrtimer_restart on_timer(struct hrtimer *timer) {
   static uint8_t cycleCount = 0;
 
   hrtimer_forward_now(timer, expTime);
-  
-  if(cycleCount == 0 && dutyCycle != 0){
-    gpio_set_value(GPIO_R, 1);
-    gpio_set_value(GPIO_G, 1);
-    gpio_set_value(GPIO_B, 1);
-  }else if(cycleCount == dutyCycle){
-    gpio_set_value(GPIO_R, 0);
-    gpio_set_value(GPIO_G, 0);
-    gpio_set_value(GPIO_B, 0);
+
+  if (cycleCount == 0) {
+    if (redDutyCycle != 0)
+      gpio_set_value(GPIO_R, 1);
+    if (greenDutyCycle != 0)
+      gpio_set_value(GPIO_G, 1);
+    if (blueDutyCycle != 0)
+      gpio_set_value(GPIO_B, 1);
+  } else {
+    if (cycleCount == redDutyCycle)
+      gpio_set_value(GPIO_R, 0);
+    if (cycleCount == greenDutyCycle)
+      gpio_set_value(GPIO_G, 0);
+    if (cycleCount == blueDutyCycle)
+      gpio_set_value(GPIO_B, 0);
   }
-  
+
   ++cycleCount;
   return HRTIMER_RESTART;
 }
 
 static int __init rgb_led_init(void) {
-  pr_info("Hello World!\n");
-  pr_info("Using duty cycle: %d\n", dutyCycle);
+  pr_info("Using duty cycles: %d %d %d\n", redDutyCycle, greenDutyCycle, blueDutyCycle);
+  pr_info("Using period: %ld ns\n", ns);
 
   if (gpio_request(GPIO_R, "RGB_R") < 0) {
     pr_err("ERROR: RGB R (%d) request\n", GPIO_R);
     goto dealloc_gpio_r;
   }
-  gpio_direction_output(GPIO_R, 1);
+  gpio_direction_output(GPIO_R, 0);
 
   if (gpio_request(GPIO_G, "RGB_G") < 0) {
     pr_err("ERROR: RGB G (%d) request\n", GPIO_G);
     goto dealloc_gpio_g;
   }
-  gpio_direction_output(GPIO_G, 1);
+  gpio_direction_output(GPIO_G, 0);
 
   if (gpio_request(GPIO_B, "RGB_B") < 0) {
     pr_err("ERROR: RGB B (%d) request\n", GPIO_B);
     goto dealloc_gpio_b;
   }
-  gpio_direction_output(GPIO_B, 1);
+  gpio_direction_output(GPIO_B, 0);
 
   hrtimer_init(&pwmCycler, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
   pwmCycler.function = on_timer;
-  expTime = ktime_set(0, ns); // 162760, i.t.
+  expTime = ktime_set(0, ns);
   hrtimer_start(&pwmCycler, expTime, HRTIMER_MODE_REL);
 
   return 0;
@@ -84,8 +87,6 @@ dealloc_gpio_r:
 }
 
 static void __exit rgb_led_exit(void) {
-  pr_info("Goodbye Cruel World!\n");
-
   hrtimer_cancel(&pwmCycler);
 
   gpio_set_value(GPIO_R, 0);


### PR DESCRIPTION
The kernel module now implements a bit-banging output on the GPIO for the red, green, and blue channels of the LED.  The output is phase-locked at 48Hz with 8-bit resolution.

Testing:  Created a new RPi image and booted it.  Loaded the module with a variety of periods and duty  cycles until an acceptable output was found.  Scoped the lines with a ADALM2K oscilloscope, with some sample captures below:
50% duty cycle:
![image](https://github.com/user-attachments/assets/d409ac39-495b-4cb2-b7e7-0f19094d683f)
Minimum-on duty cycle:
![image](https://github.com/user-attachments/assets/1ab177af-3ed5-409d-99c5-5c68dcd00144)
Minimum-off duty cycle:
![image](https://github.com/user-attachments/assets/0fb7469a-c2fe-4bd8-9879-b13d7b40ba72)
