### PR TITLE
#9: Implement RGB chardev Interface

### DIFF
--- a/kernelspace/rgb-led/rgb-led.c
+++ b/kernelspace/rgb-led/rgb-led.c
@@ -35,11 +35,12 @@ static atomic_t colorBufferInUse = ATOMIC_INIT(PING);
 DEFINE_MUTEX(changeColorMutex);
 
 static int update_color(color_t newColor) {
+  if (mutex_lock_interruptible(&changeColorMutex) != 0)
+    return EINTR;
+
   const int bufferUsed = atomic_read(&colorBufferInUse);
   if (bufferUsed != PING && bufferUsed != PONG)
     return EINVAL;
-  if (mutex_lock_interruptible(&changeColorMutex) != 0)
-    return EINTR;
 
   if (bufferUsed == PING) {
     // Update pong and swap

--- a/kernelspace/rgb-led/rgb-led.c
+++ b/kernelspace/rgb-led/rgb-led.c
@@ -1,25 +1,61 @@
+#include "linux/printk.h"
+#include <linux/cdev.h>
+#include <linux/errno.h>
+#include <linux/fs.h>
 #include <linux/gpio.h>
 #include <linux/hrtimer.h>
+#include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/ktime.h>
 #include <linux/module.h>
 #include <linux/moduleparam.h>
+#include <linux/mutex.h>
+#include <linux/types.h>
+#include <linux/uaccess.h>
+
+// HW PWM INTERFACE
 
 #define GPIO_R (514) // Header J8-3
 #define GPIO_G (515) // Header J8-5
 #define GPIO_B (516) // Header J8-7
 
-// load time parameter for the duty cycle
-int redDutyCycle = 0;
-module_param(redDutyCycle, int, 0);
-int greenDutyCycle = 0;
-module_param(greenDutyCycle, int, 0);
-int blueDutyCycle = 0;
-module_param(blueDutyCycle, int, 0);
+typedef struct {
+  uint8_t red;
+  uint8_t green;
+  uint8_t blue;
+} color_t;
+
+static color_t pingColor = {.red = 0, .green = 0, .blue = 0};
+static color_t pongColor = {.red = 0, .green = 0, .blue = 0};
+#define PING (1)
+#define PONG (0)
+// synchronizes the color used with the interrupt
+static atomic_t colorBufferInUse = ATOMIC_INIT(PING);
+// synchronized between setting the color (not interrupt safe)
+DEFINE_MUTEX(changeColorMutex);
+
+static int update_color(color_t newColor) {
+  const int bufferUsed = atomic_read(&colorBufferInUse);
+  if (bufferUsed != PING && bufferUsed != PONG)
+    return EINVAL;
+  if (mutex_lock_interruptible(&changeColorMutex) != 0)
+    return EINTR;
+
+  if (bufferUsed == PING) {
+    // Update pong and swap
+    pongColor = newColor;
+    atomic_set(&colorBufferInUse, PONG);
+  } else {
+    // Update ping and swap
+    pingColor = newColor;
+    atomic_set(&colorBufferInUse, PING);
+  }
+  mutex_unlock(&changeColorMutex);
+  return 0;
+}
 
 // load time parameter for the period of the PWM cycle
-long ns = 80000; // roughly 48Hz
-module_param(ns, long, 200);
+const long PERIOD_NS = 80000; // roughly 48Hz
 
 struct hrtimer pwmCycler;
 ktime_t expTime;
@@ -28,20 +64,22 @@ enum hrtimer_restart on_timer(struct hrtimer *timer) {
   static uint8_t cycleCount = 0;
 
   hrtimer_forward_now(timer, expTime);
+  const int bufferUsed = atomic_read(&colorBufferInUse);
+  color_t colorValue = bufferUsed == PING ? pingColor : pongColor;
 
   if (cycleCount == 0) {
-    if (redDutyCycle != 0)
+    if (colorValue.red != 0)
       gpio_set_value(GPIO_R, 1);
-    if (greenDutyCycle != 0)
+    if (colorValue.green != 0)
       gpio_set_value(GPIO_G, 1);
-    if (blueDutyCycle != 0)
+    if (colorValue.blue != 0)
       gpio_set_value(GPIO_B, 1);
   } else {
-    if (cycleCount == redDutyCycle)
+    if (cycleCount == colorValue.red)
       gpio_set_value(GPIO_R, 0);
-    if (cycleCount == greenDutyCycle)
+    if (cycleCount == colorValue.green)
       gpio_set_value(GPIO_G, 0);
-    if (cycleCount == blueDutyCycle)
+    if (cycleCount == colorValue.blue)
       gpio_set_value(GPIO_B, 0);
   }
 
@@ -49,9 +87,60 @@ enum hrtimer_restart on_timer(struct hrtimer *timer) {
   return HRTIMER_RESTART;
 }
 
-static int __init rgb_led_init(void) {
-  pr_info("Using duty cycles: %d %d %d\n", redDutyCycle, greenDutyCycle, blueDutyCycle);
-  pr_info("Using period: %ld ns\n", ns);
+// CHARDEV INTERFACE
+
+static ssize_t color_write(struct file *file, const char __user *data, size_t data_size, loff_t *offset) {
+  // assuming global device, the file does not contain useful information
+  (void)file;
+  // position data is not used
+  (void)offset;
+
+  if (!access_ok(data, data_size)) {
+    return -EINVAL;
+  }
+
+  if (data_size != 3) {
+    // Prevent ambiguous interpretations
+    return -EINVAL;
+  }
+
+  char localData[3];
+  if (copy_from_user(localData, data, data_size) != 0) {
+    return -EINVAL;
+  }
+
+  color_t newColor = {.red = localData[0], .green = localData[1], .blue = localData[2]};
+  const int updateColorResult = update_color(newColor);
+  if (updateColorResult != 0)
+    return -updateColorResult;
+
+  // report success
+  file->f_pos += data_size;
+  return data_size;
+}
+
+static struct cdev led_cdev;
+static int led_cdev_major;
+
+// write-only device
+static struct file_operations const fileOps = {
+    .owner = THIS_MODULE,
+    .write = color_write,
+};
+
+static int create_chrdev(void) {
+  int err;
+  int devno = MKDEV(led_cdev_major, 0);
+
+  cdev_init(&led_cdev, &fileOps);
+  led_cdev.owner = THIS_MODULE;
+  led_cdev.ops = &fileOps;
+  err = cdev_add(&led_cdev, devno, 1);
+  return err;
+}
+
+static int __init
+rgb_led_init(void) {
 
   if (gpio_request(GPIO_R, "RGB_R") < 0) {
     pr_err("ERROR: RGB R (%d) request\n", GPIO_R);
@@ -73,11 +162,28 @@ static int __init rgb_led_init(void) {
 
   hrtimer_init(&pwmCycler, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
   pwmCycler.function = on_timer;
-  expTime = ktime_set(0, ns);
+  expTime = ktime_set(0, PERIOD_NS);
   hrtimer_start(&pwmCycler, expTime, HRTIMER_MODE_REL);
+
+  dev_t dev = 0;
+  if (alloc_chrdev_region(&dev, 0, 1, "rgb-led") < 0) {
+    pr_err("ERROR: Could not get a device number allocated");
+    goto stop_timer;
+  }
+
+  led_cdev_major = MAJOR(dev);
+
+  if (create_chrdev() != 0) {
+    pr_err("ERROR: Could not create chardev interface");
+    goto release_chrdev;
+  }
 
   return 0;
 
+release_chrdev:
+  unregister_chrdev_region(dev, 1);
+stop_timer:
+  hrtimer_cancel(&pwmCycler);
 dealloc_gpio_b:
   gpio_free(GPIO_G);
 dealloc_gpio_g:

--- a/meta-remote_led/recipes-remote_led/led-autostart/files/remote-led
+++ b/meta-remote_led/recipes-remote_led/led-autostart/files/remote-led
@@ -1,11 +1,38 @@
 #!/bin/sh
 
+load_module() {
+  module_name=$1
+  # remove first parameter to get the rest of the files specified
+  shift
+  create_device="$*"
+  modprobe "$module_name" || exit 1
+  if [ "$create_device" ]; then
+    major_number=$(awk '$2=="'"$module_name"'" {print $1}' </proc/devices)
+    for device in $create_device; do
+      mknod "$device" c "$major_number" 0
+    done
+  fi
+}
+
+unload_module() {
+  module_name=$1
+  # remove first parameter to get the rest of the files specified
+  shift
+  rm_device="$*"
+  if [ "$rm_device" ]; then
+    for device in $create_device; do
+      rm -rf "$device"
+    done
+  fi
+  modprobe -r "$module_name" || exit 1
+}
+
 case "$1" in
 "start")
-  modprobe rgb-led redDutyCycle=200 greenDutyCycle=0 blueDutyCycle=255
+  load_module rgb-led /dev/rgb-led
   ;;
 "stop")
-  modprobe -r rgb-led
+  unload_module rgb-led /dev/rgb-led
   ;;
 *)
   echo "Usage: $0 [start|stop]"

--- a/userspace/remote-led/app/main.cpp
+++ b/userspace/remote-led/app/main.cpp
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
   sigaddset(&blockedSignals, SIGTERM);
   pthread_sigmask(SIG_BLOCK, &blockedSignals, nullptr);
 
-  static constexpr auto RGB_COLOR_ENDPOINT{"/tmp/rgb"};
+  static constexpr auto RGB_COLOR_ENDPOINT{"/dev/rgb-led"};
   LockableWrapper<std::ofstream> rgbOutput{std::ofstream{RGB_COLOR_ENDPOINT, std::ios::binary}};
 
   static constexpr networking::PortNumber PORT_NUMBER{18658};


### PR DESCRIPTION
Implements the chardev interface for the RGB LED.  Repoints the userspace application to use the device file.

Testing:
Deployed a new image and booted the system, and started the `remote-led` application.  Executed commands like `echo -e '\x00\x00\x00' | nc -w1 <rpi address>:18658` and confirmed that the RGB color specified showed up on the LED.

Closes #9.