### PR TITLE
#17: Start Userspace Application on Boot

### DIFF
--- a/meta-remote_led/recipes-remote_led/led-autostart/files/remote-led
+++ b/meta-remote_led/recipes-remote_led/led-autostart/files/remote-led
@@ -30,8 +30,10 @@ unload_module() {
 case "$1" in
 "start")
   load_module rgb-led /dev/rgb-led
+  start-stop-daemon -S -n remote-led -a /usr/bin/remote-led
   ;;
 "stop")
+  start-stop-daemon -K -n remote-led
   unload_module rgb-led /dev/rgb-led
   ;;
 *)

--- a/meta-remote_led/recipes-remote_led/led-autostart/led-autostart.bb
+++ b/meta-remote_led/recipes-remote_led/led-autostart/led-autostart.bb
@@ -11,7 +11,10 @@ INITSCRIPT_NAME:${PN} = "remote-led"
 
 FILES:${PN} += "${sysconfdir}/init.d/remote-led"
 
+RDEPENDS:${PN} += "rgb-led"
+RDEPENDS:${PN} += "remote-led"
+
 do_install:append(){
   install -d ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/remote-led ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/remote-led ${D}${sysconfdir}/init.d/
 }

--- a/userspace/remote-led/app/main.cpp
+++ b/userspace/remote-led/app/main.cpp
@@ -9,8 +9,13 @@
 #include <fstream>
 #include <iostream>
 #include <stop_token>
+#include <unistd.h>
 
 int main(int argc, char **argv) {
+
+  if (daemon(0, 0)) {
+    std::cerr << "ERR: Could not daemonize" << std::endl;
+  }
 
   sigset_t blockedSignals;
   sigemptyset(&blockedSignals);


### PR DESCRIPTION
Modifies the autostart script to start/teardown the `remote-led` userspace application after the LED device file was created and to tear down the application before unloading the driver.  The application was modified to allow it to run in daemon mode.

Testing:
Built a new image and deployed to hardware.  On boot, the application is available and can be written to with simple commands like `echo -e '\x00\x00\x00' | nc -w1 <rpi address> 18658`.  It's stopped on shutdown.

Closes #17.